### PR TITLE
Bugfix: Type mismatch when writing resolved hosts (bytes) to file (str)

### DIFF
--- a/enumerid.py
+++ b/enumerid.py
@@ -529,6 +529,8 @@ if __name__ == '__main__':
 		output_file = open(options.output, 'a+')
 		for data in dumper.data:
 			try:
+				if isinstance(data, bytes):
+					data = data.decode()
 				output_file.write(data + '\n')
 			except UnicodeEncodeError:
 				continue


### PR DESCRIPTION
Found a minor bug when using the `-d ` flag to resolve hostnames to IP addresses.

```
root@kali:/opt/enumerid# python3 enumerid.py -r 516 -o domain-controllers.txt -f domain.local -d gooduser:badpassw0rd@10.1.1.1
[*] Connection target: 10.1.1.1                                                            
[+] Found domain: DOMAIN                        
[*] Enumerating RID 516 in the DOMAIN domain..                                                 
[*] Group RID detected. Enumerating users/hosts in group..

DC1.domain.local,10.1.1.1                                                            
DC2.domain.local,10.1.1.2                                                            
                                                
Traceback (most recent call last):                                                            
  File "enumerid.py", line 532, in <module>                                                   
    output_file.write(data + '\n')                                                            
TypeError: can't concat str to bytes         
```

The issue is caused by certain changes in python3 which retrieves socket data as a bytearray, so it must be explicitly decoded via the `bytes.decode()` method for it to be treated as a string. This is to prevent introduction of binary data into non-binary files, and vice-versa. 

The solution checks if the data value is an instance of `bytes` and explicitly decodes it before it is written to the non-binary output file.
